### PR TITLE
fix: close image file when sending Pushover notification

### DIFF
--- a/scrape_epic_games.py
+++ b/scrape_epic_games.py
@@ -24,9 +24,16 @@ def send_pushover_notification(user_key, app_token, title, message, image_path=N
             "title": title,
             "message": message
         }
-        files = {"attachment": open(image_path, "rb")} if image_path else None
-
-        response = requests.post("https://api.pushover.net/1/messages.json", data=data, files=files)
+        if image_path:
+            with open(image_path, "rb") as img_file:
+                files = {"attachment": img_file}
+                response = requests.post(
+                    "https://api.pushover.net/1/messages.json", data=data, files=files
+                )
+        else:
+            response = requests.post(
+                "https://api.pushover.net/1/messages.json", data=data
+            )
         if response.status_code == 200:
             print("Pushover notification sent successfully.")
         else:


### PR DESCRIPTION
## Summary
- ensure Pushover image attachments are opened with a `with` block

## Testing
- `python -m py_compile scrape_epic_games.py`


------
https://chatgpt.com/codex/tasks/task_e_683f726673e0832db217f33d2ec6be2b