### PR TITLE
Fix Docker capitalization in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Python-based web scraper that fetches the weekly free games from the Epic Games Store. The scraper supports Docker for easy deployment and maintains a full history of past free games. Additionally, it provides information about upcoming games.
 
-It uses Selenium in a docker to load the page as the Free Game section is loaded using JavaScript, so basic scraping doesn't work. User-agent spoofing is used otherwise the page won't load correctly.
+It uses Selenium in a Docker container to load the page as the Free Game section is loaded using JavaScript, so basic scraping doesn't work. User-agent spoofing is used otherwise the page won't load correctly.
 
 ---
 


### PR DESCRIPTION
## Summary
- fix Docker capitalization in README

## Testing
- `grep -n "Selenium" README.md`

------
https://chatgpt.com/codex/tasks/task_e_683f72652304832d9482b85ba09c2c88